### PR TITLE
Copyedits and Practical Update

### DIFF
--- a/id3v2.4.0-frames.txt
+++ b/id3v2.4.0-frames.txt
@@ -1846,7 +1846,118 @@ A.   Appendix A - Genre List from ID3v1
      77. Musical
      78. Rock & Roll
      79. Hard Rock
- 
+     80. Folk
+     81. Folk-Rock
+     82. National Folk
+     83. Swing
+     84. Fast Fusion
+     85. Bebop
+     86. Latin
+     87. Revival
+     88. Celtic
+     89. Bluegrass
+     90. Avantgarde
+     91. Gothic Rock
+     92. Progressive Rock
+     93. Psychedelic Rock
+     94. Symphonic Rock
+     95. Slow Rock
+     96. Big Band
+     97. Chorus
+     98. Easy Listening
+     99. Acoustic
+    100. Humour
+    101. Speech
+    102. Chanson
+    103. Opera
+    104. Chamber Music
+    105. Sonata
+    106. Symphony
+    107. Booty Bass
+    108. Primus
+    109. Porn Groove
+    110. Satire
+    111. Slow Jam
+    112. Club
+    113. Tango
+    114. Samba
+    115. Folklore
+    116. Ballad
+    117. Power Ballad
+    118. Rhythmic Soul
+    119. Freestyle
+    120. Duet
+    121. Punk Rock
+    122. Drum Solo
+    123. A cappella
+    124. Euro-House
+    125. Dance Hall
+    126. Goa music
+    127. Drum  &. Bass
+    128. Club-House
+    129. Hardcore Techno
+    130. Terror
+    131. Indie
+    132. BritPop
+    133. Negerpunk
+    134. Polsk Punk
+    135. Beat
+    136. Christian Gangsta Rap
+    137. Heavy Metal
+    138. Black Metal
+    139. Crossover
+    140. Contemporary Christian
+    141. Christian Rock
+    142. Merengue
+    143. Salsa
+    144. Thrash Metal
+    145. Anime
+    146. Jpop
+    147. Synthpop
+    148. Abstract
+    149. Art Rock
+    150. Baroque
+    151. Bhangra
+    152. Big beat
+    153. Breakbeat
+    154. Chillout
+    155. Downtempo
+    156. Dub
+    157. EBM
+    158. Eclectic
+    159. Electro
+    160. Electroclash
+    161. Emo
+    162. Experimental
+    163. Garage
+    164. Global
+    165. IDM
+    166. Illbient
+    167. Industro-Goth
+    168. Jam Band
+    169. Krautrock
+    170. Leftfield
+    171. Lounge
+    172. Math Rock
+    173. New Romantic
+    174. Nu-Breakz
+    175. Post-Punk
+    176. Post-Rock
+    177. Psytrance
+    178. Shoegaze
+    179. Space Rock
+    180. Trop Rock
+    181. World Music
+    182. Neoclassical
+    183. Audiobook
+    184. Audio Theatre
+    185. Neue Deutsche Welle
+    186. Podcast
+    187. Indie-Rock
+    188. G-Funk
+    189. Dubstep
+    190. Garage Rock
+    191. Psybient
 
 8.   Author's address
 

--- a/id3v2.4.0-frames.txt
+++ b/id3v2.4.0-frames.txt
@@ -1766,198 +1766,199 @@ A.   Appendix A - Genre List from ID3v1
 
    The following genres are defined in ID3v1
 
-      0. Blues
-      1. Classic Rock
-      2. Country
-      3. Dance
-      4. Disco
-      5. Funk
-      6. Grunge
-      7. Hip-Hop
-      8. Jazz
-      9. Metal
-     10. New Age
-     11. Oldies
-     12. Other
-     13. Pop
-     14. R&B
-     15. Rap
-     16. Reggae
-     17. Rock
-     18. Techno
-     19. Industrial
-     20. Alternative
-     21. Ska
-     22. Death Metal
-     23. Pranks
-     24. Soundtrack
-     25. Euro-Techno
-     26. Ambient
-     27. Trip-Hop
-     28. Vocal
-     29. Jazz+Funk
-     30. Fusion
-     31. Trance
-     32. Classical
-     33. Instrumental
-     34. Acid
-     35. House
-     36. Game
-     37. Sound Clip
-     38. Gospel
-     39. Noise
-     40. AlternRock
-     41. Bass
-     42. Soul
-     43. Punk
-     44. Space
-     45. Meditative
-     46. Instrumental Pop
-     47. Instrumental Rock
-     48. Ethnic
-     49. Gothic
-     50. Darkwave
-     51. Techno-Industrial
-     52. Electronic
-     53. Pop-Folk
-     54. Eurodance
-     55. Dream
-     56. Southern Rock
-     57. Comedy
-     58. Cult
-     59. Gangsta
-     60. Top 40
-     61. Christian Rap
-     62. Pop/Funk
-     63. Jungle
-     64. Native American
-     65. Cabaret
-     66. New Wave
-     67. Psychedelic
-     68. Rave
-     69. Showtunes
-     70. Trailer
-     71. Lo-Fi
-     72. Tribal
-     73. Acid Punk
-     74. Acid Jazz
-     75. Polka
-     76. Retro
-     77. Musical
-     78. Rock & Roll
-     79. Hard Rock
-     80. Folk
-     81. Folk-Rock
-     82. National Folk
-     83. Swing
-     84. Fast Fusion
-     85. Bebop
-     86. Latin
-     87. Revival
-     88. Celtic
-     89. Bluegrass
-     90. Avantgarde
-     91. Gothic Rock
-     92. Progressive Rock
-     93. Psychedelic Rock
-     94. Symphonic Rock
-     95. Slow Rock
-     96. Big Band
-     97. Chorus
-     98. Easy Listening
-     99. Acoustic
-    100. Humour
-    101. Speech
-    102. Chanson
-    103. Opera
-    104. Chamber Music
-    105. Sonata
-    106. Symphony
-    107. Booty Bass
-    108. Primus
-    109. Porn Groove
-    110. Satire
-    111. Slow Jam
-    112. Club
-    113. Tango
-    114. Samba
-    115. Folklore
-    116. Ballad
-    117. Power Ballad
-    118. Rhythmic Soul
-    119. Freestyle
-    120. Duet
-    121. Punk Rock
-    122. Drum Solo
-    123. A cappella
-    124. Euro-House
-    125. Dance Hall
-    126. Goa music
-    127. Drum  &. Bass
-    128. Club-House
-    129. Hardcore Techno
-    130. Terror
-    131. Indie
-    132. BritPop
-    133. Negerpunk
-    134. Polsk Punk
-    135. Beat
-    136. Christian Gangsta Rap
-    137. Heavy Metal
-    138. Black Metal
-    139. Crossover
-    140. Contemporary Christian
-    141. Christian Rock
-    142. Merengue
-    143. Salsa
-    144. Thrash Metal
-    145. Anime
-    146. Jpop
-    147. Synthpop
-    148. Abstract
-    149. Art Rock
-    150. Baroque
-    151. Bhangra
-    152. Big beat
-    153. Breakbeat
-    154. Chillout
-    155. Downtempo
-    156. Dub
-    157. EBM
-    158. Eclectic
-    159. Electro
-    160. Electroclash
-    161. Emo
-    162. Experimental
-    163. Garage
-    164. Global
-    165. IDM
-    166. Illbient
-    167. Industro-Goth
-    168. Jam Band
-    169. Krautrock
-    170. Leftfield
-    171. Lounge
-    172. Math Rock
-    173. New Romantic
-    174. Nu-Breakz
-    175. Post-Punk
-    176. Post-Rock
-    177. Psytrance
-    178. Shoegaze
-    179. Space Rock
-    180. Trop Rock
-    181. World Music
-    182. Neoclassical
-    183. Audiobook
-    184. Audio Theatre
-    185. Neue Deutsche Welle
-    186. Podcast
-    187. Indie-Rock
-    188. G-Funk
-    189. Dubstep
-    190. Garage Rock
-    191. Psybient
+      0. $00 Blues
+      1. $01 Classic Rock
+      2. $02 Country
+      3. $03 Dance
+      4. $04 Disco
+      5. $05 Funk
+      6. $06 Grunge
+      7. $07 Hip-Hop
+      8. $08 Jazz
+      9. $09 Metal
+     10. $0A New Age
+     11. $0B Oldies
+     12. $0C Other
+     13. $0D Pop
+     14. $0E R&B
+     15. $0F Rap
+     16. $10 Reggae
+     17. $11 Rock
+     18. $12 Techno
+     19. $13 Industrial
+     20. $14 Alternative
+     21. $15 Ska
+     22. $16 Death Metal
+     23. $17 Pranks
+     24. $18 Soundtrack
+     25. $19 Euro-Techno
+     26. $1A Ambient
+     27. $1B Trip-Hop
+     28. $1C Vocal
+     29. $1D Jazz+Funk
+     30. $1E Fusion
+     31. $1F Trance
+     32. $20 Classical
+     33. $21 Instrumental
+     34. $22 Acid
+     35. $23 House
+     36. $24 Game
+     37. $25 Sound Clip
+     38. $26 Gospel
+     39. $27 Noise
+     40. $28 AlternRock
+     41. $29 Bass
+     42. $2A Soul
+     43. $2B Punk
+     44. $2C Space
+     45. $2D Meditative
+     46. $2E Instrumental Pop
+     47. $2F Instrumental Rock
+     48. $30 Ethnic
+     49. $31 Gothic
+     50. $32 Darkwave
+     51. $33 Techno-Industrial
+     52. $34 Electronic
+     53. $35 Pop-Folk
+     54. $36 Eurodance
+     55. $37 Dream
+     56. $38 Southern Rock
+     57. $39 Comedy
+     58. $3A Cult
+     59. $3B Gangsta
+     60. $3C Top 40
+     61. $3D Christian Rap
+     62. $3E Pop/Funk
+     63. $3F Jungle
+     64. $40 Native American
+     65. $41 Cabaret
+     66. $42 New Wave
+     67. $43 Psychedelic
+     68. $44 Rave
+     69. $45 Showtunes
+     70. $46 Trailer
+     71. $47 Lo-Fi
+     72. $48 Tribal
+     73. $49 Acid Punk
+     74. $4A Acid Jazz
+     75. $4B Polka
+     76. $4C Retro
+     77. $4D Musical
+     78. $4E Rock & Roll
+     79. $4F Hard Rock
+     80. $50 Folk
+     81. $51 Folk-Rock
+     82. $52 National Folk
+     83. $53 Swing
+     84. $54 Fast Fusion
+     85. $55 Bebop
+     86. $56 Latin
+     87. $57 Revival
+     88. $58 Celtic
+     89. $59 Bluegrass
+     90. $5A Avantgarde
+     91. $5B Gothic Rock
+     92. $5C Progressive Rock
+     93. $5D Psychedelic Rock
+     94. $5E Symphonic Rock
+     95. $5F Slow Rock
+     96. $60 Big Band
+     97. $61 Chorus
+     98. $62 Easy Listening
+     99. $63 Acoustic
+    100. $64 Humour
+    101. $65 Speech
+    102. $66 Chanson
+    103. $67 Opera
+    104. $68 Chamber Music
+    105. $69 Sonata
+    106. $6A Symphony
+    107. $6B Booty Bass
+    108. $6C Primus
+    109. $6D Porn Groove
+    110. $6E Satire
+    111. $6F Slow Jam
+    112. $70 Club
+    113. $71 Tango
+    114. $72 Samba
+    115. $73 Folklore
+    116. $74 Ballad
+    117. $75 Power Ballad
+    118. $76 Rhythmic Soul
+    119. $77 Freestyle
+    120. $78 Duet
+    121. $79 Punk Rock
+    122. $7A Drum Solo
+    123. $7B A cappella
+    124. $7C Euro-House
+    125. $7D Dance Hall
+    126. $7E Goa music
+    127. $7F Drum  & Bass
+    128. $80 Club-House
+    129. $81 Hardcore Techno
+    130. $82 Terror
+    131. $83 Indie
+    132. $84 BritPop
+    133. $85 Negerpunk
+    134. $86 Polsk Punk
+    135. $87 Beat
+    136. $88 Christian Gangsta Rap
+    137. $89 Heavy Metal
+    138. $8A Black Metal
+    139. $8B Crossover
+    140. $8C Contemporary Christian
+    141. $8D Christian Rock
+    142. $8E Merengue
+    143. $8F Salsa
+    144. $90 Thrash Metal
+    145. $91 Anime
+    146. $92 Jpop
+    147. $93 Synthpop
+    148. $94 Abstract
+    149. $95 Art Rock
+    150. $96 Baroque
+    151. $97 Bhangra
+    152. $98 Big beat
+    153. $99 Breakbeat
+    154. $9A Chillout
+    155. $9B Downtempo
+    156. $9C Dub
+    157. $9D EBM
+    158. $9E Eclectic
+    159. $9F Electro
+    160. $A0 Electroclash
+    161. $A1 Emo
+    162. $A2 Experimental
+    163. $A3 Garage
+    164. $A4 Global
+    165. $A5 IDM
+    166. $A6 Illbient
+    167. $A7 Industro-Goth
+    168. $A8 Jam Band
+    169. $A9 Krautrock
+    170. $AA Leftfield
+    171. $AB Lounge
+    172. $AC Math Rock
+    173. $AD New Romantic
+    174. $AE Nu-Breakz
+    175. $AF Post-Punk
+    176. $B0 Post-Rock
+    177. $B1 Psytrance
+    178. $B2 Shoegaze
+    179. $B3 Space Rock
+    180. $B4 Trop Rock
+    181. $BB5 World Music
+    182. $B6 Neoclassical
+    183. $B7 Audiobook
+    184. $B8 Audio Theatre
+    185. $B9 Neue Deutsche Welle
+    186. $BA Podcast
+    187. $BB Indie-Rock
+    188. $BC G-Funk
+    189. $BD Dubstep
+    190. $BE Garage Rock
+    191. $BF Psybient
+    192. - 255. $C0 .. $FF reserved
 
 8.   Author's address
 

--- a/id3v2.4.0-frames.txt
+++ b/id3v2.4.0-frames.txt
@@ -12,7 +12,7 @@ Status of this document
 
    This document is an informal standard and replaces the ID3v2.3.0
    standard [ID3v2]. A formal standard will use another revision number
-   even if the content is identical to document. The contents in this
+   even if the content is identical to this document. The contents in this
    document may change for clarifications but never for added or altered
    functionallity.
 
@@ -24,7 +24,7 @@ Abstract
    This document describes the frames natively supported by ID3v2.4.0,
    which is a revised version of the ID3v2 informal standard [ID3v2.3.0]
    version 2.3.0. The ID3v2 offers a flexible way of storing audio meta
-   information within audio file itself. The information may be
+   information within the audio file itself. The information may be
    technical information, such as equalisation curves, as well as title,
    performer, copyright etc.
 
@@ -128,7 +128,7 @@ Abstract
 
 4.   Declared ID3v2 frames
 
-   The following frames are declared in this draft.
+   The following frames are declared in this informal standard.
 
   4.19  AENC Audio encryption
   4.14  APIC Attached picture
@@ -254,8 +254,8 @@ Abstract
 
    The text information frames are often the most important frames,
    containing information like artist, album and more. There may only be
-   one text information frame of its kind in an tag. All text
-   information frames supports multiple strings, stored as a null
+   one text information frame of its kind in a tag. All text
+   information frames support multiple strings, stored as a null
    separated list, where null is reperesented by the termination code
    for the charater encoding. All text frame identifiers begin with "T".
    Only text frame identifiers begin with "T", with the exception of the
@@ -271,48 +271,54 @@ Abstract
 4.2.1.   Identification frames
 
   TIT1
-   The 'Content group description' frame is used if the sound belongs to
+   The 'Content Group Description' frame is used if the sound belongs to
    a larger category of sounds/music. For example, classical music is
    often sorted in different musical sections (e.g. "Piano Concerto",
-   "Weather - Hurricane").
+   "Weather - Hurricane") and audiobooks are often part of a series.
 
   TIT2
-   The 'Title/Songname/Content description' frame is the actual name of
+   The 'Title/Songname/Content Description' frame is the actual name of
    the piece (e.g. "Adagio", "Hurricane Donna").
 
   TIT3
-   The 'Subtitle/Description refinement' frame is used for information
-   directly related to the contents title (e.g. "Op. 16" or "Performed
-   live at Wembley").
+   The 'Subtitle/Description Refinement' frame is used for information
+   directly related to the contents title (e.g. "Op. 16", "Performed
+   live at Wembley" or "DJ Noise remix").
 
   TALB
-   The 'Album/Movie/Show title' frame is intended for the title of the
-   recording (or source of sound) from which the audio in the file is
+   The 'Album/Movie/Show Title' frame is intended for the title of the
+   recording or source of sound from which the audio in the file is
    taken.
 
+  TOTI
+   The 'Original Title' frame is intended for the title of the category
+   (TIT1), piece (TIT2) or variant (TIT3), if for example the music in
+   the file is a cover of a previously released song.
+
   TOAL
-   The 'Original album/movie/show title' frame is intended for the title
-   of the original recording (or source of sound), if for example the
-   music in the file should be a cover of a previously released song.
+   The 'Original Album/Movie/Show Title' frame is intended for the title
+   of the original recording or source of sound (TALB), if for example
+   the sound is from a movie dubbed in another language.
 
   TRCK
-   The 'Track number/Position in set' frame is a numeric string
+   The 'Track Number/Position in Set' frame is a numeric string
    containing the order number of the audio-file on its original
    recording. This MAY be extended with a "/" character and a numeric
    string containing the total number of tracks/elements on the original
-   recording. E.g. "4/9".
+   recording, e.g. "4/9" for the fourth out of nine items.
 
   TPOS
-   The 'Part of a set' frame is a numeric string that describes which
+   The 'Part of a Set' frame is a numeric string that describes which
    part of a set the audio came from. This frame is used if the source
    described in the "TALB" frame is divided into several mediums, e.g. a
-   double CD. The value MAY be extended with a "/" character and a
-   numeric string containing the total number of parts in the set. E.g.
-   "1/2".
+   double CD or a season. The value MAY be extended with a "/" character 
+   and a numeric string containing the total number of parts in the set,
+   e.g. "1/2" for the first out of two items.
 
   TSST
-   The 'Set subtitle' frame is intended for the subtitle of the part of
-   a set this track belongs to.
+   The 'Set Subtitle' frame is intended for the subtitle of the part of
+   a set (TPOS) this track belongs to, e.g. "Summer" for "2/4" or 
+   "Night" for "2/2".
 
   TSRC
    The 'ISRC' frame should contain the International Standard Recording
@@ -322,46 +328,48 @@ Abstract
 4.2.2.   Involved persons frames
 
   TPE1
-   The 'Lead artist/Lead performer/Soloist/Performing group' is
-   used for the main artist.
+   The 'Lead Artist/Lead Performer/Soloist/Performing Group/
+   MC/Narrator/Host' frame is used for the main artist.
 
   TPE2
    The 'Band/Orchestra/Accompaniment' frame is used for additional
    information about the performers in the recording.
 
   TPE3
-   The 'Conductor' frame is used for the name of the conductor.
+   The 'Conductor/DJ/Producer/Director' frame is used for the name of 
+   the conductor in classical music or the director of audioplays.
 
   TPE4
-   The 'Interpreted, remixed, or otherwise modified by' frame contains
-   more information about the people behind a remix and similar
-   interpretations of another existing piece.
+   The 'Interpreted, Remixed, Translated or otherwise Modified by'
+   frame contains more information about the people behind a remix
+   and similar interpretations of another existing piece.
 
   TOPE
-   The 'Original artist/performer' frame is intended for the performer
+   The 'Original Artist/Performer' frame is intended for the performer
    of the original recording, if for example the music in the file
    should be a cover of a previously released song.
 
   TEXT
-   The 'Lyricist/Text writer' frame is intended for the writer of the
-   text or lyrics in the recording.
+   The 'Lyricist/Text Writer/Author' frame is intended for the writer
+   of the text or lyrics in the recording.
 
   TOLY
-   The 'Original lyricist/text writer' frame is intended for the
-   text writer of the original recording, if for example the music in
-   the file should be a cover of a previously released song.
+   The 'Original Lyricist/Text Writer/Author' frame is intended for
+   the text writer of the original recording, if for example the music
+   in the file should be a cover of a previously released song.
 
   TCOM
-   The 'Composer' frame is intended for the name of the composer.
+   The 'Composer/Sound Engineer' frame is intended for the name of
+   the musical composer or acoustic sound engineer.
 
   TMCL
-   The 'Musician credits list' is intended as a mapping between
+   The 'Musician Credits List' is intended as a mapping between
    instruments and the musician that played it. Every odd field is an
    instrument and every even is an artist or a comma delimited list of
    artists.
 
   TIPL
-   The 'Involved people list' is very similar to the musician credits
+   The 'Involved People List' is very similar to the musician credits
    list, but maps between functions, like producer, and names.
 
   TENC
@@ -398,16 +406,28 @@ Abstract
    according to the amount of their usage, e.g. "eng" $00 "sve" $00.
 
   TCON
-   The 'Content type', which ID3v1 was stored as a one byte numeric
-   value only, is now a string. You may use one or several of the ID3v1
-   types as numerical strings, or, since the category list would be
-   impossible to maintain with accurate and up to date categories,
-   define your own. Example: "21" $00 "Eurodisco" $00
+   The 'Content Type/Genre' frame describes the musical genre or other
+   content type. It contains one or several of the ID3v1 single-byte 
+   numeric value types as numerical strings, or, since this list would
+   be impossible to maintain with accurate and up-to-date categories,
+   a custom string. Example: "21" $00 "Eurodisco" $00
 
    You may also use any of the following keywords:
    
      RX  Remix
-     CR  Cover
+     CR  Cover Version
+     IT  Instrumental Version without singing voices
+     LY  Sung Lyrics without instruments or other music
+     AB  Audiobook, usually with a single narrator
+     RP  Radioplay, usually with multiple voice actors
+     PC  Podcast, usually with steady hosts
+     IV  Interview or other dialog
+     AD  Aural Description of a video
+     ST  Soundtrack of a video
+     BG  Background Music of a video
+     AS  Ambient Sounds of a video
+     RT  Telephone Ring Tone or Alarm Sound
+     XX  Test Sound or Noise Signal
 
   TFLT
    The 'File type' frame indicates which type of audio this tag defines.
@@ -419,14 +439,52 @@ Abstract
        /2     MPEG 1/2 layer II
        /3     MPEG 1/2 layer III
        /2.5   MPEG 2.5
-       /AAC   Advanced audio compression
+       /4     MPEG 4 ALS
+       /AAC   MPEG 2/4 Advanced Audio Compression
+       /Main  AAC Main Profile
+       /Low   AAC Low Complexity Profile
+       /SSR   AAC SSR
      VQF    Transform-domain Weighted Interleave Vector Quantisation
+     VOX    Ogg Vorbis
+     SPX    Speex
+     APE    Monkey's Audio
+     FLC    FLAC
+     ACX
+       /3     AC-3
+       /4     AC-4
+       /E     EAC-3
+     DTS    Dolby True Sound
+       /H     DTS-HD, True HD
+       /E     DTS Express
+       /L     DTS Lossless
+     OPS    OPUS
+     3GP
+       /G     GSM
+       /E     EVRC
+       /S     SMV
+       /Q     QCELP
+       /N     AMR Narrow Band
+       /W     AMR Wide Band
      PCM    Pulse Code Modulated audio
+       /a     A-Law
+       /mu    µ-Law
+       /F32B  32-bit float, big endian
+       /F32L  32-bit float, little endian
+       /F64B  64-bit float, big endian
+       /F64L  64-bit float, little endian
+       /S32B  32-bit integer, big endian
+       /S32L  32-bit integer, little endian
+       /S24B  24-bit integer, big endian
+       /S24L  24-bit integer, little endian
+       /S16B  16-bit integer, big endian
+       /S16L  16-bit integer, little endian
+       /raw   unsigned raw
+       /S8    8-bit integer
 
-   but other types may be used, but not for these types though. This is
-   used in a similar way to the predefined types in the "TMED" frame,
-   but without parentheses. If this frame is not present audio type is
-   assumed to be "MPG".
+   Other types may be used, but not for these types. This is used in
+   a similar way to the predefined types in the "TMED" frame, but
+   without parentheses. If this frame is not present, the audio type
+   is assumed to be "MPG".
 
   TMED
    The 'Media type' frame describes from which media the sound
@@ -435,17 +493,17 @@ Abstract
    "VID/PAL/VHS" $00.
 
     DIG    Other digital media
-      /A    Analogue transfer from media
+      /A     Analogue transfer from media
 
     ANA    Other analogue media
-      /WAC  Wax cylinder
-      /8CA  8-track tape cassette
+      /WAC   Wax cylinder
+      /8CA   8-track tape cassette
 
     CD     CD
-      /A    Analogue transfer from media
-      /DD   DDD
-      /AD   ADD
-      /AA   AAD
+      /A     Analogue transfer from media
+      /DD    DDD
+      /AD    ADD
+      /AA    AAD
 
     LD     Laserdisc
 
@@ -458,62 +516,99 @@ Abstract
       /80    80 rpm
 
     MD     MiniDisc
-      /A    Analogue transfer from media
+      /A     Analogue transfer from media
 
-    DAT    DAT
-      /A    Analogue transfer from media
-      /1    standard, 48 kHz/16 bits, linear
-      /2    mode 2, 32 kHz/16 bits, linear
-      /3    mode 3, 32 kHz/12 bits, non-linear, low speed
-      /4    mode 4, 32 kHz/12 bits, 4 channels
-      /5    mode 5, 44.1 kHz/16 bits, linear
-      /6    mode 6, 44.1 kHz/16 bits, 'wide track' play
+    DAT    Digital Audio Tape
+      /A     Analogue transfer from media
+      /1     standard, 48 kHz/16 bits, linear
+      /2     mode 2, 32 kHz/16 bits, linear
+      /3     mode 3, 32 kHz/12 bits, non-linear, low speed
+      /4     mode 4, 32 kHz/12 bits, 4 channels
+      /5     mode 5, 44.1 kHz/16 bits, linear
+      /6     mode 6, 44.1 kHz/16 bits, 'wide track' play
 
     DCC    DCC
       /A    Analogue transfer from media
 
     DVD    DVD
       /A    Analogue transfer from media
+      /M    DVD-Audio
+      /H    HD-DVD
+      /B    Bluray Disc
 
     TV     Television
-      /PAL    PAL
-      /NTSC   NTSC
+      /PAL    PAL / EBU
+      /NTSC   NTSC / SMPTE / FCC
       /SECAM  SECAM
+      /A      Analog signal
+      /DVB    ETSC Digital Video Broadcasting
+      /ISDB   Japanese Integrated Services Digital Broadcasting
+      /ATSC   US DTTV
+      /DMB    Digital Media Broadcasting
+      /IP     IPTV or VOD stream
+      /D      Digital signal
+      /SD     Standard definition
+      /ED     Enhanced definition
+      /HD     High definition
+      /UHD    Ultra-high definition
+      /T      Terrestrial
+      /S      Satellite
+      /C      Cable
+      /M      Mobile
 
     VID    Video
       /PAL    PAL
       /NTSC   NTSC
       /SECAM  SECAM
-      /VHS    VHS
-      /SVHS   S-VHS
-      /BETA   BETAMAX
+      /VHS    VHS tape
+      /SVHS   S-VHS tape
+      /BETA   Betamax tape
+      /LP     Long-Play recording
+      /SP     Standard-Play recording
 
     RAD    Radio
-      /FM   FM
-      /AM   AM
-      /LW   LW
-      /MW   MW
+      /FM    Ultra Short Wave, Frequency Modulation
+      /AM    Short Wave, Amplitude Modulation
+      /LW    Long Wave
+      /MW    Medium Wave
+      /DRM   Digital Radio Mondiale
+      /DAB   Digital Audio Broadcasting (Plus)
+      /DX    Digital Satellite Radio (DSR)
 
     TEL    Telephone
-      /I    ISDN
+      /A     analog, Plain Old Telephone System (POTS)
+      /I     digital, Integrated Service Digital Network (ISDN)
+      /2     2G, GSM
+      /3     3G, UMTS
+      /4     4G, Long-Term Evolution (LTE)
+      /5     5G
+      /V     Voice over Internet Protocol (VoIP)
 
-    MC     MC (normal cassette)
-      /4    4.75 cm/s (normal speed for a two sided cassette)
-      /9    9.5 cm/s
-      /I    Type I cassette (ferric/normal)
-      /II   Type II cassette (chrome)
-      /III  Type III cassette (ferric chrome)
-      /IV   Type IV cassette (metal)
+    MC     Music Cassette
+      /4     4.75 cm/s (normal speed for a two sided cassette)
+      /9     9.5 cm/s (normal speed for a single-sided cassette)
+      /I     Type I cassette (ferric/normal)
+      /II    Type II cassette (chrome)
+      /III   Type III cassette (ferric chrome)
+      /IV    Type IV cassette (metal)
 
     REE    Reel
-      /9    9.5 cm/s
-      /19   19 cm/s
-      /38   38 cm/s
-      /76   76 cm/s
-      /I    Type I cassette (ferric/normal)
-      /II   Type II cassette (chrome)
-      /III  Type III cassette (ferric chrome)
-      /IV   Type IV cassette (metal)
+      /9     9.5 cm/s
+      /19    19 cm/s
+      /38    38 cm/s
+      /76    76 cm/s
+      /I     Type I cassette (ferric/normal)
+      /II    Type II cassette (chrome)
+      /III   Type III cassette (ferric chrome)
+      /IV    Type IV cassette (metal)
+      
+    MIC    Microphone
+      /S     Studio
+      /H     Headset
+      /I     Internal
+      /D     Dictation device
+      
+    CG     Computer-generated sound
 
   TMOO
    The 'Mood' frame is intended to reflect the mood of the audio with a
@@ -523,102 +618,117 @@ Abstract
 4.2.4.   Rights and license frames
 
   TCOP
-   The 'Copyright message' frame, in which the string must begin with a
+   The 'Copyright Message' frame, in which the string must begin with a
    year and a space character (making five characters), is intended for
    the copyright holder of the original sound, not the audio file
    itself. The absence of this frame means only that the copyright
    information is unavailable or has been removed, and must not be
    interpreted to mean that the audio is public domain. Every time this
    field is displayed the field must be preceded with "Copyright " (C) "
-   ", where (C) is one character showing a C in a circle.
+   ", where (C) is Unicode character U+00A9 showing a C in a circle.
 
   TPRO
-   The 'Produced notice' frame, in which the string must begin with a
+   The 'Production Notice' frame, in which the string must begin with a
    year and a space character (making five characters), is intended for
    the production copyright holder of the original sound, not the audio
    file itself. The absence of this frame means only that the production
    copyright information is unavailable or has been removed, and must
    not be interpreted to mean that the audio is public domain. Every
    time this field is displayed the field must be preceded with
-   "Produced " (P) " ", where (P) is one character showing a P in a
-   circle.
+   "Produced " (P) " ", where (P) is Unicode character U+2117 showing
+   a P in a circle.
 
   TPUB
-   The 'Publisher' frame simply contains the name of the label or
+   The 'Publisher/Label' frame simply contains the name of the label or
    publisher.
 
   TOWN
-   The 'File owner/licensee' frame contains the name of the owner or
-   licensee of the file and it's contents.
+   The 'File Owner/Licensee' frame contains the name of the owner or
+   licensee of the file and its contents.
 
   TRSN
-   The 'Internet radio station name' frame contains the name of the
-   internet radio station from which the audio is streamed.
+   The 'Radio Station Name' frame contains the name of the
+   (internet) radio station from which the audio is streamed.
 
   TRSO
-   The 'Internet radio station owner' frame contains the name of the
-   owner of the internet radio station from which the audio is
-   streamed.
+   The 'Radio Station Owner' frame contains the name of the owner
+   of the internet radio station from which the audio is streamed.
 
-4.2.5.   Other text frames
+
+4.2.5.   Timestamp frames
+
+Timestamp format is described in the ID3v2 structure document [ID3v2-strct].
+All timestamp frames begin with TD.
+
+  TDEN
+   The 'Encoding Time' frame contains a timestamp describing when the
+   audio was encoded. 
+
+  TDOR
+   The 'Original Release Time' frame contains a timestamp describing
+   when the original recording of the audio was released.
+
+  TDRC
+   The 'Recording Time' frame contains a timestamp describing when the
+   audio was recorded.
+
+  TDRL
+   The 'Release Time' frame contains a timestamp describing when the
+   audio was first released.
+
+  TDTG
+   The 'Tagging Time' frame contains a timestamp describing then the
+   audio was tagged.
+
+
+4.2.6.   Sort order frames
+
+All Sort Order frames begin with TS.
+
+  TSO2
+   The 'Album Artist Sort Order' frame defines a string which should be used
+   instead of the Album Artist (TPE2) for sorting purposes.
+   
+  TSOA
+   The 'Album Sort Order' frame defines a string which should be used
+   instead of the album name (TALB) for sorting purposes. E.g. an album
+   named "A Soundtrack" might preferably be sorted as "Soundtrack".
+
+  TSOC
+   The 'Composer Sort Order' frame defines a string which should be used
+   instead of the Composer (TCOM) for sorting purposes.
+
+  TSOP
+   The 'Performer Sort Order' frame defines a string which should be
+   used instead of the Performer (TPE1) for sorting purposes.
+
+  TSOT
+   The 'Title Sort Order' frame defines a string which should be used
+   instead of the Title (TIT2) for sorting purposes.
+
+
+4.2.7.   Other text frames
 
   TOFN
-   The 'Original filename' frame contains the preferred filename for the
+   The 'Original Filename' frame contains the preferred filename for the
    file, since some media doesn't allow the desired length of the
-   filename. The filename is case sensitive and includes its suffix.
+   filename. The filename is case sensitive and includes its suffix. 
+   Characters like "/", "\" and ":" are allowed, but MUST NOT be 
+   interpreted as parts of a path and therefore MAY need substitution.
 
   TDLY
-   The 'Playlist delay' defines the numbers of milliseconds of silence
+   The 'Playlist Delay' defines the numbers of milliseconds of silence
    that should be inserted before this audio. The value zero indicates
    that this is a part of a multifile audio track that should be played
    continuously.
 
-  TDEN
-   The 'Encoding time' frame contains a timestamp describing when the
-   audio was encoded. Timestamp format is described in the ID3v2
-   structure document [ID3v2-strct].
-
-  TDOR
-   The 'Original release time' frame contains a timestamp describing
-   when the original recording of the audio was released. Timestamp
-   format is described in the ID3v2 structure document [ID3v2-strct].
-
-  TDRC
-   The 'Recording time' frame contains a timestamp describing when the
-   audio was recorded. Timestamp format is described in the ID3v2
-   structure document [ID3v2-strct].
-
-  TDRL
-   The 'Release time' frame contains a timestamp describing when the
-   audio was first released. Timestamp format is described in the ID3v2
-   structure document [ID3v2-strct].
-
-  TDTG
-   The 'Tagging time' frame contains a timestamp describing then the
-   audio was tagged. Timestamp format is described in the ID3v2
-   structure document [ID3v2-strct].
-
   TSSE
-   The 'Software/Hardware and settings used for encoding' frame
+   The 'Software/Hardware and Settings Used for Encoding' frame
    includes the used audio encoder and its settings when the file was
    encoded. Hardware refers to hardware encoders, not the computer on
    which a program was run.
 
-  TSOA
-   The 'Album sort order' frame defines a string which should be used
-   instead of the album name (TALB) for sorting purposes. E.g. an album
-   named "A Soundtrack" might preferably be sorted as "Soundtrack".
-
-  TSOP
-   The 'Performer sort order' frame defines a string which should be
-   used instead of the performer (TPE2) for sorting purposes.
-
-  TSOT
-   The 'Title sort order' frame defines a string which should be used
-   instead of the title (TIT2) for sorting purposes.
-
-
-4.2.6.   User defined text information frame
+4.2.8.   User defined text information frame
 
    This frame is intended for one-string text information concerning the
    audio file in a similar way to the other "T"-frames. The frame body
@@ -626,7 +736,7 @@ Abstract
    string, followed by the actual string. There may be more than one
    "TXXX" frame in each tag, but only one with the same description.
 
-     <Header for 'User defined text information frame', ID: "TXXX">
+   TXXX
      Text encoding     $xx
      Description       <text string according to encoding> $00 (00)
      Value             <text string according to encoding>
@@ -634,49 +744,48 @@ Abstract
 
 4.3.   URL link frames
 
-   With these frames dynamic data such as webpages with touring
+   With these frames, dynamic data such as webpages with touring
    information, price information or plain ordinary news can be added to
    the tag. There may only be one URL [URL] link frame of its kind in an
    tag, except when stated otherwise in the frame description. If the
    text string is followed by a string termination, all the following
    information should be ignored and not be displayed. All URL link
    frame identifiers begins with "W". Only URL link frame identifiers
-   begins with "W", except for "WXXX". All URL link frames have the
-   following format:
+   begins with "W", except for "WXXX" described in 4.3.2. All URL link 
+   frames have the following format:
 
-     <Header for 'URL link frame', ID: "W000" - "WZZZ", excluding "WXXX"
-     described in 4.3.2.>
+   W000 - WXXW, WXXY - WZZZ
      URL              <text string>
 
 
 4.3.1.   URL link frames - details
 
   WCOM
-   The 'Commercial information' frame is a URL pointing at a webpage
+   The 'Commercial Information' frame is a URL pointing at a webpage
    with information such as where the album can be bought. There may be
    more than one "WCOM" frame in a tag, but not with the same content.
 
   WCOP
-   The 'Copyright/Legal information' frame is a URL pointing at a
+   The 'Copyright/Legal Information' frame is a URL pointing at a
    webpage where the terms of use and ownership of the file is
    described.
 
   WOAF
-   The 'Official audio file webpage' frame is a URL pointing at a file
+   The 'Official Audio File Webpage' frame is a URL pointing at a file
    specific webpage.
 
   WOAR
-   The 'Official artist/performer webpage' frame is a URL pointing at
+   The 'Official Artist/Performer Webpage' frame is a URL pointing at
    the artists official webpage. There may be more than one "WOAR" frame
    in a tag if the audio contains more than one performer, but not with
    the same content.
 
   WOAS
-   The 'Official audio source webpage' frame is a URL pointing at the
+   The 'Official Audio Source Webpage' frame is a URL pointing at the
    official webpage for the source of the audio file, e.g. a movie.
 
   WORS
-   The 'Official Internet radio station homepage' contains a URL
+   The 'Official Radio Station Homepage' contains a URL
    pointing at the homepage of the internet radio station.
 
   WPAY
@@ -684,7 +793,7 @@ Abstract
    the process of paying for this file.
 
   WPUB
-   The 'Publishers official webpage' frame is a URL pointing at the
+   The 'Official Publisher Webpage' frame is a URL pointing at the
    official webpage for the publisher.
 
 
@@ -697,36 +806,36 @@ Abstract
    [ISO-8859-1]. There may be more than one "WXXX" frame in each tag,
    but only one with the same description.
 
-     <Header for 'User defined URL link frame', ID: "WXXX">
+   WXXX
      Text encoding     $xx
      Description       <text string according to encoding> $00 (00)
      URL               <text string>
 
 
-4.4.   Music CD identifier
+4.4.   Audio CD identifier
 
    This frame is intended for music that comes from a CD, so that the CD
    can be identified in databases such as the CDDB [CDDB]. The frame
    consists of a binary dump of the Table Of Contents, TOC, from the CD,
-   which is a header of 4 bytes and then 8 bytes/track on the CD plus 8
-   bytes for the 'lead out', making a maximum of 804 bytes. The offset
+   which is a header of 4 bytes and then 8 bytes per track on the CD plus
+   8 bytes for the 'lead out', making a maximum of 804 bytes. The offset
    to the beginning of every track on the CD should be described with a
-   four bytes absolute CD-frame address per track, and not with absolute
-   time. When this frame is used the presence of a valid "TRCK" frame is
-   REQUIRED, even if the CD's only got one track. It is recommended that
-   this frame is always added to tags originating from CDs. There may
-   only be one "MCDI" frame in each tag.
+   4-byte absolute CD-frame address per track, and not with absolute
+   time. When this frame is used, the presence of a valid "TRCK" frame is
+   REQUIRED, even if the CD has only got one track. It is recommended
+   that this frame is always added to tags originating from CDs. There
+   may only be one "MCDI" frame in each tag.
 
-     <Header for 'Music CD identifier', ID: "MCDI">
+   MCDI
      CD TOC                <binary data>
 
 
 4.5.   Event timing codes
 
-   This frame allows synchronisation with key events in the audio. The
-   header is:
+   The 'Event Timing Codes' frame allows synchronisation with key events
+   in the audio. Its header is:
 
-     <Header for 'Event timing codes', ID: "ETCO">
+   ETCO
      Time stamp format    $xx
 
    Where time stamp format is:
@@ -737,7 +846,7 @@ Abstract
    Absolute time means that every stamp contains the time from the
    beginning of the file.
 
-   Followed by a list of key events in the following format:
+   The header is ollowed by a list of key events in the following format:
 
      Type of event   $xx
      Time stamp      $xx (xx ...)
@@ -746,31 +855,47 @@ Abstract
    sound or after the previous event. All events MUST be sorted in
    chronological order. The type of event is as follows:
 
-     $00  padding (has no meaning)
-     $01  end of initial silence
-     $02  intro start
-     $03  main part start
-     $04  outro start
-     $05  outro end
-     $06  verse start
-     $07  refrain start
-     $08  interlude start
-     $09  theme start
-     $0A  variation start
-     $0B  key change
-     $0C  time change
-     $0D  momentary unwanted noise (Snap, Crackle & Pop)
-     $0E  sustained noise
-     $0F  sustained noise end
-     $10  intro end
-     $11  main part end
-     $12  verse end
-     $13  refrain end
-     $14  theme end
-     $15  profanity
-     $16  profanity end
+     $00  Padding (has no meaning)
+     $01  End of initial silence
+     $02  Intro start
+     $03  Main part start
+     $04  Outro start
+     $05  Outro end
+     $06  Verse start
+     $07  Refrain start
+     $08  Interlude start
+     $09  Theme start
+     $0A  Variation start
+     $0B  Key change
+     $0C  Time change
+     $0D  Momentary unwanted noise (Snap, Crackle & Pop)
+     $0E  Sustained noise
+     $0F  Sustained noise end
+     $10  Intro end
+     $11  Main part end
+     $12  Verse end
+     $13  Refrain end
+     $14  Theme end
+     $15  Profanity
+     $16  Profanity end
+     $17  Announcement
+     $18  Announcement end
+     $19  Advertising
+     $1A  Advertising end
+     $1B  Single speaker
+     $1C  Single speaker end
+     $1D  Multiple speaker quabble
+     $1E  Multiple speaker quabble end
+     $1F  Narration
+     $20  Narration end
+     $21  Question
+     $22  Question end
+     $23  Answer
+     $24  Answer end
+     $25  Applause
+     $26  Applause end
 
-     $17-$DF  reserved for future use
+     $27-$DF  reserved for future use
 
      $E0-$EF  not predefined synch 0-F
 
@@ -782,8 +907,8 @@ Abstract
           the value $FF have the same function)
 
    Terminating the start events such as "intro start" is OPTIONAL. The
-   'Not predefined synch's ($E0-EF) are for user events. You might want
-   to synchronise your music to something, like setting off an explosion
+   'Not predefined synch's ($E0-EF) are for user events. Users might want
+   to synchronise their music to something, like setting off an explosion
    on-stage, activating a screensaver etc.
 
    There may only be one "ETCO" frame in each tag.
@@ -812,7 +937,7 @@ Abstract
    milliseconds deviation', must be a multiple of four. There may only
    be one "MLLT" frame in each tag.
 
-     <Header for 'Location lookup table', ID: "MLLT">
+   MLLT
      MPEG frames between reference  $xx xx
      Bytes between reference        $xx xx xx
      Milliseconds between reference $xx xx xx
@@ -845,7 +970,7 @@ Abstract
    the beat description occurs. There may only be one "SYTC" frame in
    each tag.
 
-     <Header for 'Synchronised tempo codes', ID: "SYTC">
+   SYTC
      Time stamp format   $xx
      Tempo data          <binary data>
 
@@ -869,7 +994,7 @@ Abstract
    lyrics/text transcription' frame in each tag, but only one with the
    same language and content descriptor.
 
-     <Header for 'Unsynchronised lyrics/text transcription', ID: "USLT">
+   USLT
      Text encoding        $xx
      Language             $xx xx xx
      Content descriptor   <text string according to encoding> $00 (00)
@@ -885,7 +1010,7 @@ Abstract
    content descriptor, represented with as terminated text string. If no
    descriptor is entered, 'Content descriptor' is $00 (00) only.
 
-     <Header for 'Synchronised lyrics/text', ID: "SYLT">
+   SYLT
      Text encoding        $xx
      Language             $xx xx xx
      Time stamp format    $xx
@@ -961,7 +1086,7 @@ Abstract
    comment frame in each tag, but only one with the same language and
    content descriptor.
 
-     <Header for 'Comment', ID: "COMM">
+   COMM
      Text encoding          $xx
      Language               $xx xx xx
      Short content descrip. <text string according to encoding> $00 (00)
@@ -971,7 +1096,7 @@ Abstract
 4.11.   Relative volume adjustment (2)
 
    This is a more subjective frame than the previous ones. It allows the
-   user to say how much he wants to increase/decrease the volume on each
+   user to say how much they want to increase/decrease the volume on each
    channel when the file is played. The purpose is to be able to align
    all files to a reference volume, so that you don't have to change the
    volume constantly. This frame may also be used to balance adjust the
@@ -981,7 +1106,7 @@ Abstract
    $04 00 and -2 dB is $FC 00. There may be more than one "RVA2" frame
    in each tag, but only one with the same identification string.
 
-     <Header for 'Relative volume adjustment (2)', ID: "RVA2">
+   RVA2
      Identification          <text string> $00
 
    The 'identification' string is used to identify the situation and/or
@@ -1016,7 +1141,7 @@ Abstract
    more than one "EQU2" frame in each tag, but only one with the same
    identification string.
 
-     <Header of 'Equalisation (2)', ID: "EQU2">
+   EQU2
      Interpolation method  $xx
      Identification        <text string> $00
 
@@ -1069,7 +1194,7 @@ Abstract
    reverb is applied symmetric). There may only be one "RVRB" frame in
    each tag.
 
-     <Header for 'Reverb', ID: "RVRB">
+   RVRB
      Reverb left (ms)                 $xx xx
      Reverb right (ms)                $xx xx
      Reverb bounces, left             $xx
@@ -1099,7 +1224,7 @@ Abstract
    The use of linked files should however be used sparingly since there
    is the risk of separation of files.
 
-     <Header for 'Attached picture', ID: "APIC">
+   APIC
      Text encoding      $xx
      MIME type          <text string> $00
      Picture type       $xx
@@ -1108,26 +1233,29 @@ Abstract
 
 
    Picture type:  $00  Other
-                  $01  32x32 pixels 'file icon' (PNG only)
+                  $01  32x32 pixels PNG file icon
                   $02  Other file icon
-                  $03  Cover (front)
-                  $04  Cover (back)
+                  $03  Front cover
+                  $04  Back cover
                   $05  Leaflet page
                   $06  Media (e.g. label side of CD)
                   $07  Lead artist/lead performer/soloist
                   $08  Artist/performer
-                  $09  Conductor
-                  $0A  Band/Orchestra
-                  $0B  Composer
+                  $09  Conductor/DJ
+                  $0A  Band/orchestra
+                  $0B  Composer/author
                   $0C  Lyricist/text writer
-                  $0D  Recording Location
+                  $0D  Recording location
                   $0E  During recording
                   $0F  During performance
                   $10  Movie/video screen capture
-                  $11  A bright coloured fish
+                  $11  reserved
                   $12  Illustration
                   $13  Band/artist logotype
                   $14  Publisher/Studio logotype
+                  $15  Poster
+                  $16  Banner
+                  $17  Wallpaper
 
 
 4.15.   General encapsulated object
@@ -1154,12 +1282,12 @@ Abstract
 
    This is simply a counter of the number of times a file has been
    played. The value is increased by one every time the file begins to
-   play. There may only be one "PCNT" frame in each tag. When the
-   counter reaches all one's, one byte is inserted in front of the
-   counter thus making the counter eight bits bigger.  The counter must
-   be at least 32-bits long to begin with.
+   be played. There may only be one "PCNT" frame in each tag. When the
+   counter reaches all 1s, one byte is inserted in front of the 
+   counter, thus making the counter 8 bits bigger. The counter must be
+   at least 32-bits long to begin with.
 
-     <Header for 'Play counter', ID: "PCNT">
+   PCNT
      Counter        $xx xx xx xx (xx ...)
 
 
@@ -1169,19 +1297,19 @@ Abstract
    Many interesting applications could be found to this frame such as a
    playlist that features better audio files more often than others or
    it could be used to profile a person's taste and find other 'good'
-   files by comparing people's profiles. The frame contains the email
-   address to the user, one rating byte and a four byte play counter,
-   intended to be increased with one for every time the file is played.
-   The email is a terminated string. The rating is 1-255 where 1 is
-   worst and 255 is best. 0 is unknown. If no personal counter is wanted
-   it may be omitted. When the counter reaches all one's, one byte is
-   inserted in front of the counter thus making the counter eight bits
-   bigger in the same away as the play counter ("PCNT"). There may be
-   more than one "POPM" frame in each tag, but only one with the same
-   email address.
+   files by comparing people's profiles. The frame contains a unique 
+   user ID (e.g. an email address), 1 rating byte and a 4-byte play 
+   counter, intended to be increased with one for every time the file 
+   is played for at least 90% of its length. The user ID is a terminated
+   string. The rating is 1-255 where 1 is worst and 255 is best. 0 is
+   unknown. If no personal counter is wanted it may be omitted. When the
+   counter reaches all 1s, 1 byte is inserted in front of the counter, 
+   thus making the counter 8 bits bigger in the same away as the play
+   counter ("PCNT"). There may be more than one "POPM" frame in each 
+   tag, but only one with the same user ID.
 
-     <Header for 'Popularimeter', ID: "POPM">
-     Email to user   <text string> $00
+   POPM
+     User ID         <text string> $00
      Rating          $xx
      Counter         $xx xx xx xx (xx ...)
 
@@ -1213,7 +1341,7 @@ Abstract
    The 'Buffer size' should be kept to a minimum. There may only be one
    "RBUF" frame in each tag.
 
-     <Header for 'Recommended buffer size', ID: "RBUF">
+   RBUF
      Buffer size               $xx xx xx
      Embedded info flag        %0000000x
      Offset to next tag        $xx xx xx xx
@@ -1240,7 +1368,7 @@ Abstract
    than one "AENC" frames in a tag, but only one with the same 'Owner
    identifier'.
 
-     <Header for 'Audio encryption', ID: "AENC">
+   AENC
      Owner identifier   <text string> $00
      Preview start      $xx xx
      Preview length     $xx xx
@@ -1264,7 +1392,7 @@ Abstract
    was a physical part of the tag (i.e. only one "RVRB" frame allowed,
    whether it's linked or not).
 
-     <Header for 'Linked information', ID: "LINK">
+   LINK
      Frame identifier        $xx xx xx xx
      URL                     <text string> $00
      ID and additional data  <text string(s)>
@@ -1293,7 +1421,7 @@ Abstract
    audio stream he picked up; in effect, it states the time offset from
    the first frame in the stream. The frame layout is:
 
-     <Head for 'Position synchronisation', ID: "POSS">
+   POSS
      Time stamp format         $xx
      Position                  $xx (xx ...)
 
@@ -1316,7 +1444,7 @@ Abstract
    allowed in the text. There may be more than one 'Terms of use' frame
    in a tag, but only one with the same 'Language'.
 
-     <Header for 'Terms of use frame', ID: "USER">
+   USER
      Text encoding        $xx
      Language             $xx xx xx
      The actual text      <text string according to encoding>
@@ -1336,7 +1464,7 @@ Abstract
    of the seller as the last field in the frame. There may only be one
    "OWNE" frame in a tag.
 
-     <Header for 'Ownership frame', ID: "OWNE">
+   OWNE
      Text encoding     $xx
      Price paid        <text string> $00
      Date of purch.    <text string>
@@ -1353,10 +1481,10 @@ Abstract
    constructed by one three character currency code, encoded according
    to ISO 4217 [ISO-4217] alphabetic currency code, followed by a
    numerical value where "." is used as decimal separator. In the price
-   string several prices may be concatenated, separated by a "/"
+   string, several prices may be concatenated, separated by a "/"
    character, but there may only be one currency of each type.
 
-   The price string is followed by an 8 character date string in the
+   The price string is followed by an 8-character date string in the
    format YYYYMMDD, describing for how long the price is valid. After
    that is a contact URL, with which the user can contact the seller,
    followed by a one byte 'received as' field. It describes how the
@@ -1383,7 +1511,7 @@ Abstract
    picture is attached. There may be more than one 'commercial frame' in
    a tag, but no two may be identical.
 
-     <Header for 'Commercial frame', ID: "COMR">
+   COMR
      Text encoding      $xx
      Price string       <text string> $00
      Valid until        <text string>
@@ -1413,7 +1541,7 @@ Abstract
    See the description of the frame encryption flag in the ID3v2
    structure document [ID3v2-strct] for more information.
 
-     <Header for 'Encryption method registration', ID: "ENCR">
+   ENCR
      Owner identifier    <text string> $00
      Method symbol       $xx
      Encryption data     <binary data>
@@ -1438,7 +1566,7 @@ Abstract
    somewhere in the tag. See the description of the frame grouping flag
    in the ID3v2 structure document [ID3v2-strct] for more information.
 
-     <Header for 'Group ID registration', ID: "GRID">
+   GRID
      Owner identifier      <text string> $00
      Group symbol          $xx
      Group dependent data  <binary data>
@@ -1456,7 +1584,7 @@ Abstract
    indicated email address. The tag may contain more than one "PRIV"
    frame but only with different contents.
 
-     <Header for 'Private frame', ID: "PRIV">
+   PRIV
      Owner identifier      <text string> $00
      The private data      <binary data>
 
@@ -1469,7 +1597,7 @@ Abstract
    the signature elsewhere, e.g. in watermarks. There may be more than
    one 'signature frame' in a tag, but no two may be identical.
 
-     <Header for 'Signature frame', ID: "SIGN">
+   SIGN
      Group symbol      $xx
      Signature         <binary data>
 
@@ -1481,8 +1609,8 @@ Abstract
    tag to the beginning of the next. There may only be one 'seek frame'
    in a tag.
 
-   <Header for 'Seek frame', ID: "SEEK">
-   Minimum offset to next tag       $xx xx xx xx
+   SEEK
+     Minimum offset to next tag       $xx xx xx xx
 
 
 4.30.   Audio seek point index
@@ -1497,7 +1625,7 @@ Abstract
    milliseconds. There may only be one 'audio seek point index' frame in
    a tag.
 
-     <Header for 'Seek Point Index', ID: "ASPI">
+   ASPI
      Indexed data start (S)         $xx xx xx xx
      Indexed data length (L)        $xx xx xx xx
      Number of index points (N)     $xx xx
@@ -1505,7 +1633,7 @@ Abstract
 
    Then for every index point the following data is included;
 
-     Fraction at index (Fi)          $xx (xx)
+     Fraction at index (Fi)         $xx (xx)
 
    'Indexed data start' is a byte offset from the beginning of the file.
    'Indexed data length' is the byte length of the audio data being
@@ -1609,14 +1737,10 @@ Abstract
    media at up to about 1,5 Mbit/s, Part 3: Audio.
    Technical committee / subcommittee: JTC 1 / SC 29
     and
-   ISO/IEC 13818-3:1995
+   ISO/IEC 13818-3
    Generic coding of moving pictures and associated audio information,
    Part 3: Audio.
    Technical committee / subcommittee: JTC 1 / SC 29
-    and
-   ISO/IEC DIS 13818-3
-   Generic coding of moving pictures and associated audio information,
-   Part 3: Audio (Revision of ISO/IEC 13818-3:1995)
 
 
    [PNG] Portable Network Graphics, version 1.0
@@ -1640,97 +1764,97 @@ Abstract
 
 A.   Appendix A - Genre List from ID3v1
 
-   The following genres is defined in ID3v1
+   The following genres are defined in ID3v1
 
-      0.Blues
-      1.Classic Rock
-      2.Country
-      3.Dance
-      4.Disco
-      5.Funk
-      6.Grunge
-      7.Hip-Hop
-      8.Jazz
-      9.Metal
-     10.New Age
-     11.Oldies
-     12.Other
-     13.Pop
-     14.R&B
-     15.Rap
-     16.Reggae
-     17.Rock
-     18.Techno
-     19.Industrial
-     20.Alternative
-     21.Ska
-     22.Death Metal
-     23.Pranks
-     24.Soundtrack
-     25.Euro-Techno
-     26.Ambient
-     27.Trip-Hop
-     28.Vocal
-     29.Jazz+Funk
-     30.Fusion
-     31.Trance
-     32.Classical
-     33.Instrumental
-     34.Acid
-     35.House
-     36.Game
-     37.Sound Clip
-     38.Gospel
-     39.Noise
-     40.AlternRock
-     41.Bass
-     42.Soul
-     43.Punk
-     44.Space
-     45.Meditative
-     46.Instrumental Pop
-     47.Instrumental Rock
-     48.Ethnic
-     49.Gothic
-     50.Darkwave
-     51.Techno-Industrial
-     52.Electronic
-     53.Pop-Folk
-     54.Eurodance
-     55.Dream
-     56.Southern Rock
-     57.Comedy
-     58.Cult
-     59.Gangsta
-     60.Top 40
-     61.Christian Rap
-     62.Pop/Funk
-     63.Jungle
-     64.Native American
-     65.Cabaret
-     66.New Wave
-     67.Psychedelic
-     68.Rave
-     69.Showtunes
-     70.Trailer
-     71.Lo-Fi
-     72.Tribal
-     73.Acid Punk
-     74.Acid Jazz
-     75.Polka
-     76.Retro
-     77.Musical
-     78.Rock & Roll
-     79.Hard Rock
+      0. Blues
+      1. Classic Rock
+      2. Country
+      3. Dance
+      4. Disco
+      5. Funk
+      6. Grunge
+      7. Hip-Hop
+      8. Jazz
+      9. Metal
+     10. New Age
+     11. Oldies
+     12. Other
+     13. Pop
+     14. R&B
+     15. Rap
+     16. Reggae
+     17. Rock
+     18. Techno
+     19. Industrial
+     20. Alternative
+     21. Ska
+     22. Death Metal
+     23. Pranks
+     24. Soundtrack
+     25. Euro-Techno
+     26. Ambient
+     27. Trip-Hop
+     28. Vocal
+     29. Jazz+Funk
+     30. Fusion
+     31. Trance
+     32. Classical
+     33. Instrumental
+     34. Acid
+     35. House
+     36. Game
+     37. Sound Clip
+     38. Gospel
+     39. Noise
+     40. AlternRock
+     41. Bass
+     42. Soul
+     43. Punk
+     44. Space
+     45. Meditative
+     46. Instrumental Pop
+     47. Instrumental Rock
+     48. Ethnic
+     49. Gothic
+     50. Darkwave
+     51. Techno-Industrial
+     52. Electronic
+     53. Pop-Folk
+     54. Eurodance
+     55. Dream
+     56. Southern Rock
+     57. Comedy
+     58. Cult
+     59. Gangsta
+     60. Top 40
+     61. Christian Rap
+     62. Pop/Funk
+     63. Jungle
+     64. Native American
+     65. Cabaret
+     66. New Wave
+     67. Psychedelic
+     68. Rave
+     69. Showtunes
+     70. Trailer
+     71. Lo-Fi
+     72. Tribal
+     73. Acid Punk
+     74. Acid Jazz
+     75. Polka
+     76. Retro
+     77. Musical
+     78. Rock & Roll
+     79. Hard Rock
+ 
 
-
-8.   Author's Address
+8.   Author's address
 
    Written by
 
      Martin Nilsson
-     Rydsv�gen 246 C. 30
-     SE-584 34 Link�ping
+     Rydsvägen 246 C. 30
+     SE-584 34 Linköping
      Sweden
 
      Email: nilsson at id3.org


### PR DESCRIPTION
Besides several copyedits, including clarifications and extended examples, this patch …

- adds `TOTI ` _Original Title_ frame
- adds `TSOC` _Composer Sort Order_ frame
- adds several keywords for the `TCON` _Content Type/Genre_, `TFLT` _File Type_ and `TMED` _Media Type_ frames
- adds several predefined byte codes for the `ETCO` _Event Timing Codes_ frame
- adds several predefined byte codes for the _Picture type_ of the `APIC` _Attached Picture_ frame
- renames `TRSN` and `WORS` by dropping _Internet_ to just _Radio Station Name_ and _Official Radio Station Homepage_, respectively
- splits out _4.2.5. Timestamp frames_, _4.2.6. Sort order frames_ from _4.2.5._ (now: _4.2.7._) _Other text frames_ subsection 
- updates  Appendix A _Genre List from ID3v1_ with subsequent additions by Winamp etc.